### PR TITLE
Fix Unity 6.4+ hierarchy callback compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### Unreleased
+- Fixed compilation on Unity 6.4 and newer by using the EntityId-based Hierarchy callback while retaining the legacy callback on older Unity versions.
+
 #### v1.8.0 - 2020-06-13
 - Added DistributionOrder
 - Fixed Error for GUI Layer

--- a/Editor/AlignToolsWindow.cs
+++ b/Editor/AlignToolsWindow.cs
@@ -162,7 +162,11 @@ namespace litefeel.AlignTools
 #else
             SceneView.onSceneGUIDelegate += OnSceneGUI;
 #endif
+#if UNITY_6000_4_OR_NEWER
+            EditorApplication.hierarchyWindowItemByEntityIdOnGUI += OnHierarchyWindowItemOnGUI;
+#else
             EditorApplication.hierarchyWindowItemOnGUI += OnHierarchyWindowItemOnGUI;
+#endif
         }
 
         private void OnDisable()
@@ -172,10 +176,18 @@ namespace litefeel.AlignTools
 #else
             SceneView.onSceneGUIDelegate -= OnSceneGUI;
 #endif
+#if UNITY_6000_4_OR_NEWER
+            EditorApplication.hierarchyWindowItemByEntityIdOnGUI -= OnHierarchyWindowItemOnGUI;
+#else
             EditorApplication.hierarchyWindowItemOnGUI -= OnHierarchyWindowItemOnGUI;
+#endif
         }
 
+#if UNITY_6000_4_OR_NEWER
+        private void OnHierarchyWindowItemOnGUI(EntityId entityId, Rect selectionRect)
+#else
         private void OnHierarchyWindowItemOnGUI(int instanceID, Rect selectionRect)
+#endif
         {
             AdjustPosition.Execute();
         }
@@ -189,5 +201,4 @@ namespace litefeel.AlignTools
 
     }
 }
-
 


### PR DESCRIPTION
## Summary

- use `EditorApplication.hierarchyWindowItemByEntityIdOnGUI` on Unity 6.4 and newer
- retain `EditorApplication.hierarchyWindowItemOnGUI` on older Unity versions
- keep the existing callback behavior unchanged because the hierarchy item identifier is not consumed
- document the compatibility fix in the changelog

## Root cause

Unity 6.4 obsoleted the instance-ID-based `hierarchyWindowItemOnGUI` callback and marks its use as a compiler error. The package therefore fails to compile on current Unity 6 releases.

## Validation

- Unity 6000.5.4f1: compiled the package in an isolated batch-mode Unity project; exit code 0 with no C# compiler errors
- Unity 2019.4.40f1: compiled all package editor sources with that editor's bundled Roslyn compiler and API assemblies; exit code 0
- `git diff --check` passed